### PR TITLE
github-action: provenance for docker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,17 @@ on:
 permissions:
   contents: read
 
+env:
+  DOCKER_IMAGE_NAME: opbeans/opbeans-php
+
 jobs:
 
   release:
     runs-on: ubuntu-latest
-
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
     steps:
     - uses: actions/checkout@v4
 
@@ -25,9 +31,28 @@ jobs:
         roleId: ${{ secrets.VAULT_ROLE_ID }}
         secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-    - name: Set version if tags
-      run: echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      if: startsWith(github.ref, 'refs/tags/v')
+    - name: Extract metadata (tags, labels)
+      id: docker-meta
+      uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81  # v5.5.1
+      with:
+        images: ${{ env.DOCKER_IMAGE_NAME }}
+        tags: |
+          type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+          # tag event
+          type=ref,enable=true,prefix=,suffix=,event=tag
 
-    - name: Run publish
-      run: make publish
+    - name: Build and push image
+      id: docker-push
+      uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0  # v5.3.0
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.docker-meta.outputs.tags }}
+        labels: ${{ steps.docker-meta.outputs.labels }}
+
+    - name: Attest image
+      uses: github-early-access/generate-build-provenance@main
+      with:
+        subject-name: ${{ env.DOCKER_IMAGE_NAME }}
+        subject-digest: ${{ steps.docker-push.outputs.digest }}
+        push-to-registry: false


### PR DESCRIPTION
## What does this PR do?

Enable the provenance for docker images using the [GitHub provenance action](https://github.com/github-early-access/generate-build-provenance).

## Implementation details

I used the GitHub action native support to create the labels, build and push the docker images.

### Test

I created a test feature branch to test these changes:
- https://github.com/elastic/opbeans-php/actions/runs/8845492797

and it produced these attestations:
- https://github.com/elastic/opbeans-php/attestations